### PR TITLE
feat: add cicd

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+            submodules: recursive
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - uses: actions/setup-node@v3.5.1
+      - uses: CultureHQ/actions-yarn@v1.0.1
+      - name: build page
+        run: |
+          yarn install
+          yarn build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a GitHub Actions workflow for deploying static content to GitHub Pages.

### Detailed summary:
- Adds a workflow for deploying static content to GitHub Pages
- Runs on pushes targeting the default branch
- Allows manual runs from the Actions tab
- Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
- Allows only one concurrent deployment
- Includes a single deploy job
- Defines the environment as github-pages
- Uses actions/checkout@v3 for checking out the repository
- Uses actions/configure-pages@v3 for setting up Pages
- Uses actions/setup-node@v3.5.1 for setting up Node.js
- Uses CultureHQ/actions-yarn@v1.0.1 for installing and building the page
- Uploads the artifact to GitHub Pages
- Deploys the artifact to GitHub Pages using actions/deploy-pages@v2.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->