### PR TITLE
feat: ajuest the $ position

### DIFF
--- a/src/components/console/node/mutations-table.tsx
+++ b/src/components/console/node/mutations-table.tsx
@@ -239,14 +239,15 @@ export const MutationsTable = () => {
                     <Statistic
                         title="Mutation Avg Cost"
                         value={dashboard.mutationAvgCost}
-                        suffix="$"
+                        prefix="$"
                     />
                 </Col>
                 <Col span={6}>
                     <Statistic
                         title="Rollup Avg Cost"
+                        prefix="$"
                         value={dashboard.rollupStorageCost}
-                        suffix="$/GB"
+                        suffix="/GB"
                     />
                 </Col>
                 <Col span={6}>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Changed the prefix symbol for "Mutation Avg Cost" from "$" to "$".
- Changed the suffix symbol for "Rollup Avg Cost" from "$/GB" to "/GB".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->