### PR TITLE
Feat/eventdb

### DIFF
--- a/src/components/LeftSider.tsx
+++ b/src/components/LeftSider.tsx
@@ -18,6 +18,7 @@ const LeftSider: React.FC<{}> = memo((props) => {
     const [currentKey, setCurrentKey] = React.useState('Home')
     const { rollupStatus } = usePageContext()
     const location = useLocation()
+    const navigate = useNavigate()
     const items = [
         {
             key: 'Home',
@@ -59,6 +60,11 @@ const LeftSider: React.FC<{}> = memo((props) => {
         },
     ]
     useEffect(() => {
+        if (location.pathname === "/") {
+            setCurrentKey('Home')
+            navigate("/home")
+            return
+        }
         if (location.pathname.startsWith('/home')) {
             setCurrentKey('Home')
         } else if (location.pathname.startsWith('/database')) {

--- a/src/data-context/Config.ts
+++ b/src/data-context/Config.ts
@@ -73,8 +73,8 @@ export const chainToNodes = [
     },
     {
         chainId: 280,
-        dataRollupUrl: 'http://testnet.db3.network:26100',
-        dataIndexUrl: 'http://testnet.db3.network:26101',
+        dataRollupUrl: 'http://zksync.rollup.testnet.db3.network',
+        dataIndexUrl: 'http://zksync.index.testnet.db3.network',
         name: 'ZkSync Testnet',
         logo: zkSyncSrc,
         contractAddr: '0xB4Ec19674A67dB002fFDeB83e14f9849DA3D1020',

--- a/src/data-context/Config.ts
+++ b/src/data-context/Config.ts
@@ -73,8 +73,8 @@ export const chainToNodes = [
     },
     {
         chainId: 280,
-        dataRollupUrl: 'http://zksync.rollup.testnet.db3.network',
-        dataIndexUrl: 'http://zksync.index.testnet.db3.network',
+        dataRollupUrl: 'https://zksync.rollup.testnet.db3.network',
+        dataIndexUrl: 'https://zksync.index.testnet.db3.network',
         name: 'ZkSync Testnet',
         logo: zkSyncSrc,
         contractAddr: '0xB4Ec19674A67dB002fFDeB83e14f9849DA3D1020',

--- a/src/data-context/Config.ts
+++ b/src/data-context/Config.ts
@@ -32,7 +32,7 @@ zkSyncTestnet
 } from 'viem/chains'
 
 export const AR_SCAN_URL: string = 'https://viewblock.io/arweave/tx/'
-export const defaultChainId = 1337
+export const defaultChainId = 280
 
 export const chainToNodes = [
     {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the default chain ID and data URLs for the ZkSync Testnet.

### Detailed summary:
- Added `navigate` hook to `LeftSider.tsx`
- Added logic to set current key and navigate to `/home` if the current path is `/`
- Updated the `defaultChainId` in `Config.ts` from 1337 to 280
- Updated the `dataRollupUrl` and `dataIndexUrl` for the ZkSync Testnet in `Config.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->